### PR TITLE
song_numberカラムの削除

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -29,7 +29,6 @@ class Admin::ProductsController < ApplicationController
     end
 
     def edit
-
         @product = Product.find(params[:id])
     end
 

--- a/app/views/admin/products/_song_fields.html.erb
+++ b/app/views/admin/products/_song_fields.html.erb
@@ -1,5 +1,4 @@
 <p class="nested-fields">
 	曲：<%= f.text_field :songname %>
-	<%= f.select :song_number, options_for_select((1..30).to_a) %><br>
 	<%= link_to_remove_association '曲を削除', f %>
 </p>

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -39,7 +39,6 @@
                             <%= cd.fields_for :songs do |song| %>
                                 <p class="nested-fields">
                                     曲名: <%= song.text_field :songname %>
-                                    <%= song.collection_select :song_number, Song.all, :song_number, :song_number %><br>
                                     <%= link_to_remove_association '曲を削除', song %>
                                 </p>
                             <% end %>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -52,8 +52,8 @@
 
     <section class="col-xs-4 right">
         <h2>収録曲</h2>
-        <% cd.songs.each do |song| %>
-            <p class="product-item song"><%= song.song_number %>. <%= song.songname %></p><br>
+        <% cd.songs.each_with_index do |song, i| %>
+            <p class="product-item song"><%= i + 1 %>. <%= song.songname %></p><br>
         <% end %>
     </section>
     <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -39,8 +39,8 @@
 
     <section class="col-xs-4 right">
         <h2>収録曲</h2>
-        <% cd.songs.each do |song| %>
-            <p class="product-item song"><%= song.song_number %>. <%= song.songname %></p><br>
+        <% cd.songs.each_with_index do |song, i| %>
+            <p class="product-item song"><%= i + 1 %>. <%= song.songname %></p><br>
         <% end %>
     </section>
     <% end %>

--- a/db/migrate/20190908053528_remove_song_number_from_songs.rb
+++ b/db/migrate/20190908053528_remove_song_number_from_songs.rb
@@ -1,0 +1,5 @@
+class RemoveSongNumberFromSongs < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :songs, :song_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_01_035735) do
+ActiveRecord::Schema.define(version: 2019_09_08_053528) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer "user_id"
@@ -104,7 +104,6 @@ ActiveRecord::Schema.define(version: 2019_09_01_035735) do
   create_table "songs", force: :cascade do |t|
     t.integer "cd_id"
     t.string "songname"
-    t.integer "song_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
song_numberカラムを削除して、商品詳細ページの曲番は自動で連番になるようにしました。